### PR TITLE
Maven Snapshot Dependency Submission on PR during Dependency Review

### DIFF
--- a/.github/workflows/DepGraph.yml
+++ b/.github/workflows/DepGraph.yml
@@ -14,9 +14,6 @@ name: "Dependency Graph Upload"
 on:
   push:
     branches: [ "main" ]
-  pull_request:
-    # The branches below must be a subset of the branches above
-    branches: [ "main" ]
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,7 +1,7 @@
 name: 'Dependency Review'
 on: [pull_request]
 permissions:
-  contents: read
+  contents: write
   pull-requests: write
 jobs:
   dependency-review:
@@ -9,6 +9,8 @@ jobs:
     steps:
       - name: 'Checkout Repository'
         uses: actions/checkout@v3
+      - name: Maven Dependency Tree Dependency Submission
+        uses: advanced-security/maven-dependency-submission-action@v3
       - name: Dependency Review
         uses: actions/dependency-review-action@v3.0.6
         with:


### PR DESCRIPTION
Implement Feature:

# [Best practices for using the dependency review API and the dependency submission API together](https://docs.github.com/en/code-security/supply-chain-security/understanding-your-software-supply-chain/about-dependency-review#best-practices-for-using-the-dependency-review-api-and-the-dependency-submission-api-together)

> The dependency review API and the dependency review action both work by comparing dependency changes in a pull request with the state of your dependencies in the head commit of your target branch, which is usually your default branch.
> 
> If your repository only depends on statically defined dependencies in one of GitHub’s supported ecosystems, the dependency review API and the dependency review action work consistently.
> 
> However, you may want your dependencies to be scanned during a build and then uploaded to the dependency submission API. In this case, there are some best practices you should follow to ensure that you don’t introduce a race condition when running the processes for the dependency review API and the dependency submission API, since it could result in missing data.
> 
> The best practices you should take will depend on whether you use GitHub Actions to access the dependency submission API and the dependency review API, or whether you use direct API access.